### PR TITLE
fix: the icon will be removed when the oldName is the same as newName…

### DIFF
--- a/@iconify/tools/src/icon-set/index.ts
+++ b/@iconify/tools/src/icon-set/index.ts
@@ -405,8 +405,7 @@ export class IconSet {
 		const attributes = Object.keys(result.attributes)
 			.map(
 				(key) =>
-					` ${key}="${
-						result.attributes[key as keyof typeof result.attributes]
+					` ${key}="${result.attributes[key as keyof typeof result.attributes]
 					}"`
 			)
 			.join('');
@@ -741,6 +740,10 @@ export class IconSet {
 	 * Rename icon
 	 */
 	rename(oldName: string, newName: string): boolean {
+		if (oldName === newName) {
+			return false
+		}
+
 		const entries = this.entries;
 
 		// Remove existing item with new name


### PR DESCRIPTION
[#39](https://github.com/iconify/tools/issues/39)

add a compare of oldName and newName on the start of the rename()
if they are the same , return false ( Should this rename be considered failed? )